### PR TITLE
MINOR: lifecicle events impl

### DIFF
--- a/src/main/java/com/suleware/springboot/jpa/springboot_jpa/SpringbootJpaApplication.java
+++ b/src/main/java/com/suleware/springboot/jpa/springboot_jpa/SpringbootJpaApplication.java
@@ -27,7 +27,7 @@ public class SpringbootJpaApplication implements CommandLineRunner {
 
 	@Override
 	public void run(String... args) throws Exception {
-		concatUpperLowerLikeQuery();
+		list();
 	}
 
 	@Transactional(readOnly = true)
@@ -57,7 +57,7 @@ public class SpringbootJpaApplication implements CommandLineRunner {
 
 	@Transactional
 	public void create() {
-		Person p = new Person(null, "Lalo", "Thor", "Python");
+		Person p = new Person( "Sule", "Ware", "Typescript");
 		Person newPerson = personRepository.save(p);
 		System.out.println(newPerson);
 	}
@@ -107,7 +107,7 @@ public class SpringbootJpaApplication implements CommandLineRunner {
 
 	@Transactional(readOnly = true)
 	public void list() {
-		List<Person> persons = personRepository.findByProgrammingLanguageAndName("Java", "Jesús");
+		List<Person> persons = (List<Person>) personRepository.findAll();
 
 		persons.stream().forEach(System.out::println);
 	}

--- a/src/main/java/com/suleware/springboot/jpa/springboot_jpa/entities/Audit.java
+++ b/src/main/java/com/suleware/springboot/jpa/springboot_jpa/entities/Audit.java
@@ -1,0 +1,35 @@
+package com.suleware.springboot.jpa.springboot_jpa.entities;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Embeddable
+@Getter
+@Setter
+@ToString
+public class Audit {
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+     @PrePersist
+    public void prePersist() {
+        System.out.println("prePersist lifecicle event");
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        System.out.println("preUPdate lifecicle event");
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/suleware/springboot/jpa/springboot_jpa/entities/Person.java
+++ b/src/main/java/com/suleware/springboot/jpa/springboot_jpa/entities/Person.java
@@ -1,6 +1,7 @@
 package com.suleware.springboot.jpa.springboot_jpa.entities;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -9,12 +10,14 @@ import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
 @Entity
 @Table(name = "persons")
-@AllArgsConstructor
+@RequiredArgsConstructor
 @NoArgsConstructor
 @Getter
 @Setter
@@ -24,14 +27,19 @@ public class Person {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @NonNull
     private String name;
+    @NonNull
     private String lastname;
     @Column(name = "programming_language")
+    @NonNull
     private String programmingLanguage;
+    @Embedded
+    private Audit audit = new Audit();
 
     public Person(String name, String lastname) {
         this.name = name;
-        this. lastname = lastname;
+        this.lastname = lastname;
     }
 
 }


### PR DESCRIPTION
## Description

JPA life cycle events allow us to execute actions during the execution of DML methods.

This is useful as shown for example in this pr for Audit attributes, or loggin, etc.